### PR TITLE
perf(command): use b2s instead of string(bytes)

### DIFF
--- a/cmd/cz/cz.go
+++ b/cmd/cz/cz.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/shipengqi/golib/convutil"
 	"github.com/spf13/cobra"
 
 	"github.com/shipengqi/commitizen/internal/config"
@@ -37,7 +38,7 @@ func New() *cobra.Command {
 			}
 
 			if o.DryRun {
-				fmt.Println(string(msg))
+				fmt.Println(convutil.B2S(msg))
 				return nil
 			}
 			output, err := git.Commit(msg, o.GitOptions)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -41,7 +41,7 @@ func WorkingTreeRoot() (path string, err error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(output)), nil
+	return strings.TrimSpace(output), nil
 }
 
 func ExecPath() (string, error) {


### PR DESCRIPTION
Thank you for contributing to commitizen!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.