### PR TITLE
feat(options): add more options of 'git commit' command

### DIFF
--- a/cmd/cz/cz.go
+++ b/cmd/cz/cz.go
@@ -39,7 +39,9 @@ func New() *cobra.Command {
 
 			if o.DryRun {
 				fmt.Println(convutil.B2S(msg))
-				return nil
+				fmt.Println("")
+				// inherits the --dry-run argument from the parent command
+				o.GitOptions.DryRun = o.DryRun
 			}
 			output, err := git.Commit(msg, o.GitOptions)
 			if err != nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -62,7 +62,7 @@ func Commit(msg []byte, opts *Options) (string, error) {
 		return "", err
 	}
 
-	args := opts.Combination(temp.Name())
+	args := opts.Combine(temp.Name())
 	stdout, err := cliutil.ExecContext(context.TODO(), "git", args...)
 	if err != nil {
 		return "", err

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -62,18 +62,8 @@ func Commit(msg []byte, opts *Options) (string, error) {
 		return "", err
 	}
 
-	tokens := []string{
-		"commit",
-		"-F",
-		temp.Name(),
-	}
-	if opts.Add {
-		tokens = append(tokens, "-a")
-	}
-	if opts.SignOff {
-		tokens = append(tokens, "-s")
-	}
-	stdout, err := cliutil.ExecContext(context.TODO(), "git", tokens...)
+	args := opts.Combination(temp.Name())
+	stdout, err := cliutil.ExecContext(context.TODO(), "git", args...)
 	if err != nil {
 		return "", err
 	}

--- a/internal/git/options.go
+++ b/internal/git/options.go
@@ -3,18 +3,67 @@ package git
 import "github.com/spf13/pflag"
 
 type Options struct {
+	Quiet   bool
+	Verbose bool
 	SignOff bool
-	Add     bool
+	All     bool
+	Amend   bool
+	DryRun  bool
+	Author  string
+	Date    string
 }
 
 func NewOptions() *Options {
 	return &Options{
+		Quiet:   false,
+		Verbose: false,
 		SignOff: false,
-		Add:     false,
+		All:     false,
+		Amend:   false,
+		DryRun:  false,
+		Author:  "",
+		Date:    "",
 	}
 }
 
 func (o *Options) AddFlags(f *pflag.FlagSet) {
-	f.BoolVarP(&o.Add, "add", "a", o.Add, "tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.")
-	f.BoolVarP(&o.SignOff, "signoff", "s", o.SignOff, "add a Signed-off-by trailer by the committer at the end of the commit log message.")
+	// inherits the --dry-run argument from the parent command
+	f.BoolVarP(&o.Quiet, "quiet", "q", o.Quiet, "suppress summary after successful commit")
+	f.BoolVarP(&o.Verbose, "verbose", "v", o.Verbose, "show diff in commit message template")
+	f.StringVar(&o.Author, "author", o.Author, "override author for commit")
+	f.StringVar(&o.Date, "date", o.Date, "override date for commit")
+	f.BoolVarP(&o.All, "all", "a", o.All, "commit all changed files.")
+	f.BoolVarP(&o.SignOff, "signoff", "s", o.SignOff, "add a Signed-off-by trailer.")
+	f.BoolVar(&o.Amend, "amend", o.Amend, "amend previous commit")
+}
+
+func (o *Options) Combination(filename string) []string {
+	combined := []string{
+		"commit",
+		"-F",
+		filename,
+	}
+	if o.Quiet {
+		combined = append(combined, "-q")
+	}
+	if o.Verbose {
+		combined = append(combined, "-v")
+	}
+	if o.Author != "" {
+		combined = append(combined, "--author", o.Author)
+	}
+	if o.Date != "" {
+		combined = append(combined, "--date", o.Date)
+	}
+	if o.All {
+		combined = append(combined, "-a")
+	}
+	if o.Amend {
+		combined = append(combined, "--amend")
+	}
+	if o.DryRun {
+		combined = append(combined, "--dry-run")
+	}
+
+	return combined
 }

--- a/internal/git/options.go
+++ b/internal/git/options.go
@@ -37,33 +37,33 @@ func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&o.Amend, "amend", o.Amend, "amend previous commit")
 }
 
-func (o *Options) Combination(filename string) []string {
-	combined := []string{
+func (o *Options) Combine(filename string) []string {
+	combination := []string{
 		"commit",
 		"-F",
 		filename,
 	}
 	if o.Quiet {
-		combined = append(combined, "-q")
+		combination = append(combination, "-q")
 	}
 	if o.Verbose {
-		combined = append(combined, "-v")
+		combination = append(combination, "-v")
 	}
 	if o.Author != "" {
-		combined = append(combined, "--author", o.Author)
+		combination = append(combination, "--author", o.Author)
 	}
 	if o.Date != "" {
-		combined = append(combined, "--date", o.Date)
+		combination = append(combination, "--date", o.Date)
 	}
 	if o.All {
-		combined = append(combined, "-a")
+		combination = append(combination, "-a")
 	}
 	if o.Amend {
-		combined = append(combined, "--amend")
+		combination = append(combination, "--amend")
 	}
 	if o.DryRun {
-		combined = append(combined, "--dry-run")
+		combination = append(combination, "--dry-run")
 	}
 
-	return combined
+	return combination
 }

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -24,7 +24,7 @@ func New() *Options {
 func (o *Options) AddFlags(f *pflag.FlagSet) {
 	o.GitOptions.AddFlags(f)
 
-	f.BoolVar(&o.DryRun, "dry-run", o.DryRun, "you can use the --dry-run flag to preview the message that would be committed, without really submitting it.")
+	f.BoolVar(&o.DryRun, "dry-run", o.DryRun, "do not create a commit, but show the message and list of paths \nthat are to be committed.")
 	f.StringVarP(&o.Template, "template", "t", o.Template, "template name to use when multiple templates exist.")
 	f.BoolVarP(&o.Default, "default", "d", o.Default, "use the default template, '--default' has a higher priority than '--template'.")
 	f.BoolVar(&o.NoTTY, "no-tty", o.NoTTY, "make sure that the TTY (terminal) is never used for any output.")


### PR DESCRIPTION
add more options of 'git commit', rename '--add' to '--all'

BREAKING CHANGE: rename '--add' to '--all'

Closes #43

Thank you for contributing to commitizen!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

https://github.com/shipengqi/commitizen/issues/43

**Check list:**
- [x] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.