### PR TITLE
Added XDG Base Directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ make && ./_output/$(GOOS)/$(GOARCH)/bin/commitizen init
 
 ## Configuration
 
-You can set configuration file that `.czrc` at repository root or home directory. The configuration file that located in repository root have a priority over the one in home directory. The format is the same as the following:
+You can set configuration file that `.czrc` at repository root, home directory, or the $XDG_CONFIG_HOME/commitizen directory. The configuration file that located in repository root have a priority over the one in home directory. The format is the same as the following:
 
 ```yaml
 name: default

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,13 +35,26 @@ func New() *Config {
 
 func (c *Config) initialize() error {
 	var fpath string
+	// Check if the configuration file is local to the repo.
 	if fsutil.IsExists(RCFilename) {
 		fpath = RCFilename
 	} else {
+		// Check if the configuration file is in the user's home directory.
 		home := sysutil.HomeDir()
 		p := filepath.Join(home, RCFilename)
 		if fsutil.IsExists(p) {
 			fpath = p
+		} else {
+			// Check if the configuration file is in the configured
+			// XDG_CONFIG_HOME directory.
+			xdgConfigHome, found := os.LookupEnv("XDG_CONFIG_HOME")
+			if !found {
+				xdgConfigHome = sysutil.HomeDir()
+			}
+			p := filepath.Join(xdgConfigHome, "commitizen", RCFilename)
+			if fsutil.IsExists(p) {
+				fpath = p
+			}
 		}
 	}
 


### PR DESCRIPTION
Added support for XDG Base Directory.  If the XDG_CONFIG_HOME environment variable is set, look in the XDG_CONFIG_HOME/commitizen directory for the .czrc configuration file.  The order of operation is, look in the current repo directory, then user's home directory, and the XDG_CONFIG_HOME/commitizen directory.  If no configuration file is found, look in ~/.config/commitizen.