### PR TITLE
chore(deps): bump github.com/shipengqi/golib from 0.2.27 to 0.2.28

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,7 +17,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [ '1.22', '1.23', '1.24' ]
+        go: [ '1.23', '1.24', '1.25' ]
         os: [ ubuntu-latest, windows-latest ]
     permissions:
       contents: read  # for actions/checkout to fetch code

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shipengqi/commitizen
 
-go 1.24
+go 1.25
 
 require (
 	github.com/charmbracelet/huh v0.7.0
@@ -19,7 +19,7 @@ require (
 replace golang.org/x/net v0.35.0 => golang.org/x/net v0.37.0
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect; injdirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.38.2
 	github.com/shipengqi/component-base v0.2.11
-	github.com/shipengqi/golib v0.2.27
+	github.com/shipengqi/golib v0.2.28
 	github.com/shipengqi/log v0.2.3
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shipengqi/component-base v0.2.11 h1:oNCwa3FhFBGtKVJHSc3Tr+h9ERMX6JAVxkKToeIIh4M=
 github.com/shipengqi/component-base v0.2.11/go.mod h1:YJoIETZyVgILBSqiA7ze+WXgh8j/qz8WN+gpiTfnhc8=
-github.com/shipengqi/golib v0.2.27 h1:X9Rq5XVaJZhVxiIj2N8Gfkwxhwa1G/u4uA+tWmMYVBY=
-github.com/shipengqi/golib v0.2.27/go.mod h1:qFS6uEuKbQxVmcFpygC/PsMXphIjOx/51Y8xA2pL4QM=
+github.com/shipengqi/golib v0.2.28 h1:Z+1vdXFvQ0Pea4/zBHQ05eSABS6KTxwl2X6qmC8BMwM=
+github.com/shipengqi/golib v0.2.28/go.mod h1:WgTwni4VJw45qFWp4Ezf7n6OwybQ1yDW5nonGyREKA4=
 github.com/shipengqi/log v0.2.3 h1:dH1LEgFV1jkojNvVf2qdjcYrWIEQ7LsHPkPaeefsTcA=
 github.com/shipengqi/log v0.2.3/go.mod h1:YqXfNjg7aDR/KrXoU5KC3vCQ/YldJltQbyEwnlpJOb4=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=

--- a/hack/include/go.mk
+++ b/hack/include/go.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GO_SUPPORTED_VERSIONS ?= 1.20|1.21|1.22|1.23|1.24
+GO_SUPPORTED_VERSIONS ?= 1.20|1.21|1.22|1.23|1.24|1.25
 
 .PHONY: go.build.verify
 go.build.verify:


### PR DESCRIPTION
Thank you for contributing to commitizen!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.